### PR TITLE
Minor updates, pointed to rc1 version of crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,21 +4,21 @@ authors = ["Enzo Nocera"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos_wasi"
 description = "WASI integrations for the Leptos web framework."
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-any_spawner = { version = "0.1.1", features = ["futures-executor"] }
-throw_error = { version = "0.2.0-rc0" }
-hydration_context = { version = "0.2.0-rc0" }
+any_spawner = { git = "https://github.com/leptos-rs/leptos",  features = ["futures-executor"] }
+throw_error = { git = "https://github.com/leptos-rs/leptos"}
+hydration_context = { git = "https://github.com/leptos-rs/leptos"}
 futures = "0.3.30"
 wasi = "0.13.1+wasi-0.2.0"
-leptos = { version = "0.7.0-rc0", features = ["nonce", "ssr"] }
-leptos_meta = { version = "0.7.0-rc0", features = ["ssr"] }
-leptos_router = { version = "0.7.0-rc0", features = ["ssr"] }
-leptos_macro = { version = "0.7.0-rc0", features = ["generic"] }
-leptos_integration_utils = {version = "0.7.0-rc0" }
-server_fn = { version = "0.7.0-rc0", features = ["generic"] }
+leptos = { git = "https://github.com/leptos-rs/leptos",  features = ["nonce", "ssr"] }
+leptos_meta = { git = "https://github.com/leptos-rs/leptos",  features = ["ssr"] }
+leptos_router = { git = "https://github.com/leptos-rs/leptos",  features = ["ssr"] }
+leptos_macro = { git = "https://github.com/leptos-rs/leptos",  features = ["generic"] }
+leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos"}
+server_fn = { git = "https://github.com/leptos-rs/leptos",  features = ["generic"] }
 http = "1.1.0"
 parking_lot = "0.12.3"
 bytes = "1.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 
 [dependencies]
 any_spawner = { git = "https://github.com/leptos-rs/leptos",  features = ["futures-executor"] }
-throw_error = { git = "https://github.com/leptos-rs/leptos"}
-hydration_context = { git = "https://github.com/leptos-rs/leptos"}
+throw_error = { version = "0.2.0-rc1" }
+hydration_context = { version = "0.2.0-rc1" }
 futures = "0.3.30"
 wasi = "0.13.1+wasi-0.2.0"
-leptos = { git = "https://github.com/leptos-rs/leptos",  features = ["nonce", "ssr"] }
-leptos_meta = { git = "https://github.com/leptos-rs/leptos",  features = ["ssr"] }
-leptos_router = { git = "https://github.com/leptos-rs/leptos",  features = ["ssr"] }
-leptos_macro = { git = "https://github.com/leptos-rs/leptos",  features = ["generic"] }
-leptos_integration_utils = { git = "https://github.com/leptos-rs/leptos"}
-server_fn = { git = "https://github.com/leptos-rs/leptos",  features = ["generic"] }
+leptos = { version = "0.7.0-rc1",  features = ["nonce", "ssr"] }
+leptos_meta = { version = "0.7.0-rc1",  features = ["ssr"] }
+leptos_router = { version = "0.7.0-rc1",  features = ["ssr"] }
+leptos_macro = { version = "0.7.0-rc1",  features = ["generic"] }
+leptos_integration_utils = { version = "0.7.0-rc1" }
+server_fn = { version = "0.7.0-rc1",  features = ["generic"] }
 http = "1.1.0"
 parking_lot = "0.12.3"
 bytes = "1.7.2"

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -66,19 +66,15 @@ impl WaitPoll {
 impl Future for WaitPoll {
     type Output = ();
 
-    fn poll(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match &mut self.get_mut().0 {
             this @ WaitPollInner::Unregistered(_) => {
                 let waker = Arc::new(WaitPollWaker::new(cx.waker()));
 
                 if let Some(sender) = POLLABLE_SINK.get() {
-                    if let WaitPollInner::Unregistered(pollable) = mem::replace(
-                        this,
-                        WaitPollInner::Registered(waker.clone()),
-                    ) {
+                    if let WaitPollInner::Unregistered(pollable) =
+                        mem::replace(this, WaitPollInner::Registered(waker.clone()))
+                    {
                         sender
                             .clone()
                             .unbounded_send(TableEntry(pollable, waker.into()))
@@ -89,9 +85,7 @@ impl Future for WaitPoll {
                         unreachable!();
                     }
                 } else {
-                    panic!(
-                        "cannot create a WaitPoll before creating an Executor"
-                    );
+                    panic!("cannot create a WaitPoll before creating an Executor");
                 }
             }
             WaitPollInner::Registered(waker) => {
@@ -193,9 +187,7 @@ impl Executor {
 
         loop {
             match rx.try_recv() {
-                Err(_) => panic!(
-                    "internal error: sender of run until has been dropped"
-                ),
+                Err(_) => panic!("internal error: sender of run until has been dropped"),
                 Ok(Some(val)) => return val,
                 Ok(None) => {
                     self.poll_local();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod prelude {
     pub use crate::handler::Handler;
     pub use crate::response::Body;
     pub use crate::utils::redirect;
+    pub use any_spawner::Executor;
     pub use http::StatusCode;
     pub use wasi::exports::wasi::http::incoming_handler::{IncomingRequest, ResponseOutparam};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,8 @@ pub mod prelude {
     pub use crate::handler::Handler;
     pub use crate::response::Body;
     pub use crate::utils::redirect;
-    pub use wasi::exports::wasi::http::incoming_handler::{
-        IncomingRequest, ResponseOutparam,
-    };
+    pub use http::StatusCode;
+    pub use wasi::exports::wasi::http::incoming_handler::{IncomingRequest, ResponseOutparam};
 }
 
 /// When working with streams, this crate will try to chunk bytes with

--- a/src/response.rs
+++ b/src/response.rs
@@ -47,15 +47,7 @@ pub enum Body {
     /// The response body will be written asynchronously,
     /// this execution model is also known as
     /// "streaming".
-    Async(
-        Pin<
-            Box<
-                dyn Stream<Item = Result<Bytes, throw_error::Error>>
-                    + Send
-                    + 'static,
-            >,
-        >,
-    ),
+    Async(Pin<Box<dyn Stream<Item = Result<Bytes, throw_error::Error>> + Send + 'static>>),
 }
 
 impl From<ServerFnBody> for Body {
@@ -105,12 +97,8 @@ impl ResponseOptions {
 impl ExtendResponse for Response {
     type ResponseOptions = ResponseOptions;
 
-    fn from_stream(
-        stream: impl Stream<Item = String> + Send + 'static,
-    ) -> Self {
-        let stream = stream.map(|data| {
-            Result::<Bytes, throw_error::Error>::Ok(Bytes::from(data))
-        });
+    fn from_stream(stream: impl Stream<Item = String> + Send + 'static) -> Self {
+        let stream = stream.map(|data| Result::<Bytes, throw_error::Error>::Ok(Bytes::from(data)));
 
         Self(http::Response::new(Body::Async(Box::pin(stream))))
     }


### PR DESCRIPTION
Hi folks! Thank you for all the excellent work creating this integration :) Currently, main branch code does not build as it relies on changes in the Leptos repository that are not yet released in a tagged crate version.

This version:
1. Updates cargo.toml to point to git repository version of any_spawner temporarily + rc1 versions of other crates
2. Adds mapping for OptionalParam
3. Reexports `http::StatusCode` and `any_spawner::Executor` (temporarily) for convenience
4. Many automatic linting changes -- I have my IDE run `clippy --all` -- please let me know if these formatting changes are undesirable