### PR TITLE
provide nonce

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -451,11 +451,12 @@ fn provide_contexts(
     context_parts: Parts,
     res_opts: ResponseOptions,
 ) {
-    additional_context();
     provide_context(RequestUrl::new(context_parts.uri.path()));
     provide_context(context_parts);
     provide_context(res_opts);
+    additional_context();
     provide_server_redirect(redirect);
+    leptos::nonce::provide_nonce();
 }
 
 trait IntoRouteListing: Sized {


### PR DESCRIPTION
Provices a nonce used for [content security policy](https://en.wikipedia.org/wiki/Content_Security_Policy) to match other SSR handlers