### PR TITLE
Feat: migrate to server_fn 0.8.7 and leptos_integration_utils 0.8.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,22 +8,23 @@ version = "0.1.3"
 edition = "2021"
 
 [dependencies]
-throw_error = { version = "0.2.0" }
-hydration_context = { version = "0.2.0" }
+throw_error = { version = "0.3.0" }
+hydration_context = { version = "0.3.0" }
 futures = "0.3.30"
-wasi = "0.13.1+wasi-0.2.0"
-leptos = { version = "0.7.0",  features = ["nonce", "ssr"] }
-leptos_meta = { version = "0.7.0",  features = ["ssr"] }
-leptos_router ={ version = "0.7.0",  features = ["ssr"] }
-leptos_macro ={ version = "0.7.0",  features = ["generic"] }
-leptos_integration_utils = { version = "0.7.0" }
-server_fn = { version = "0.7.0",  features = ["generic"] }
-http = "1.1.0"
-parking_lot = "0.12.3"
-bytes = "1.7.2"
+wasi = "0.14.7+wasi-0.2.4"
+leptos = { version = "0.8.9",  features = ["nonce", "ssr"] }
+leptos_meta = { version = "0.8.5",  features = ["ssr"] }
+leptos_router ={ version = "0.8.7",  features = ["ssr"] }
+leptos_macro ={ version = "0.8.8",  features = ["generic"] }
+leptos_integration_utils = { version = "0.8.5" }
+server_fn = { version = "0.8.7",  features = ["generic"] }
+http = "1.3.1"
+parking_lot = "0.12.4"
+bytes = "1.10.1"
 routefinder = "0.5.4"
-mime_guess = "2.0"
-thiserror = "2"
+mime_guess = "2.0.5"
+thiserror = "2.0.16"
+any_spawner = { version = "0.3.0", features = ["async-executor", "futures-executor"] }
 
 [features]
 islands-router = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ leptos_meta = { version = "0.8.5",  features = ["ssr"] }
 leptos_router ={ version = "0.8.7",  features = ["ssr"] }
 leptos_macro ={ version = "0.8.8",  features = ["generic"] }
 leptos_integration_utils = { version = "0.8.5" }
-server_fn = { version = "0.8.7",  features = ["generic"] }
+server_fn = { version = "0.8.7" }
 http = "1.3.1"
 parking_lot = "0.12.4"
 bytes = "1.10.1"
@@ -27,4 +27,7 @@ thiserror = "2.0.16"
 any_spawner = { version = "0.3.0", features = ["async-executor", "futures-executor"] }
 
 [features]
+default = ["generic"]
 islands-router = []
+spin = ["server_fn/axum-no-default"]
+generic = ["server_fn/generic", "server_fn/ssr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "leptos_wasi"
-authors = ["Enzo Nocera"]
+authors = ["Enzo Nocera" , "Uriah Galang"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos_wasi"
 description = "WASI integrations for the Leptos web framework."
-version = "0.1.3"
-edition = "2021"
+version = "0.1.4"
+edition = "2024"
 
 [dependencies]
 throw_error = { version = "0.3.0" }
 hydration_context = { version = "0.3.0" }
-futures = "0.3.30"
+futures = "0.3.31"
 wasi = "0.14.7+wasi-0.2.4"
 leptos = { version = "0.8.9",  features = ["nonce", "ssr"] }
 leptos_meta = { version = "0.8.5",  features = ["ssr"] }

--- a/README.md
+++ b/README.md
@@ -50,11 +50,69 @@ Contributions are welcome!
 
 ## Usage
 
-TODO: Write a template starter for the crate.
+### Installation
+
+Add `leptos_wasi` to your `Cargo.toml` dependencies. The crate supports two modes depending on your deployment target:
+
+#### For Standard Leptos Projects
+
+For standard Leptos server-side applications (non-Spin), use the default features:
+
+```toml
+[dependencies]
+leptos_wasi = { version = "0.1.4" }
+# or explicitly:
+leptos_wasi = { version = "0.1.4", features = ["generic"] }
+```
+
+#### For Spin WebAssembly Projects
+
+For projects targeting the [Spin](https://www.fermyon.com/spin) WebAssembly runtime:
+
+```toml
+[dependencies]
+leptos_wasi = { version = "0.1.4", default-features = false, features = ["spin"] }
+```
+
+### Feature Flags
+
+- **`generic`** (default): Enables support for standard Leptos server-side applications with full generic body types
+- **`spin`**: Enables support for Spin WebAssembly runtime with simplified body types (`Bytes`)
+- **`islands-router`**: Enables islands architecture support for partial hydration
+
+### Example Usage
+
+```rust
+use leptos_wasi::Handler;
+
+// Your Leptos app component
+#[component]
+fn App() -> impl IntoView {
+    // Your app implementation
+}
+
+// In your WASI entry point
+#[export_name = "wasi:http/incoming-handler@0.2.0#handle"]
+pub unsafe extern "C" fn handle(request: IncomingRequest, response_outparam: ResponseOutparam) {
+    let handler = Handler::build(request, response_outparam)
+        .expect("Failed to build handler");
+    
+    // For Spin projects with server functions
+    #[cfg(feature = "spin")]
+    let handler = handler.with_server_fn::<YourServerFn>();
+    
+    // Generate routes and handle the request
+    handler
+        .generate_routes(App)
+        .handle_with_context(App, || {})
+        .await
+        .expect("Failed to handle request");
+}
+```
 
 ### Compatibility
 
-This crate only works with the future **Leptos v0.7**.
+This crate works with Leptos v0.8+ and supports both standard server deployments and WebAssembly Component Model deployments.
 
 ## Features
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,7 @@
 # to follow the same conventions across the organisation.
 
 # Stable options
-edition = "2021"
+edition = "2024"
 max_width = 80
 
 # Unstable options

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -26,7 +26,6 @@ use futures::{
     task::{LocalSpawnExt, SpawnExt},
     FutureExt, Stream,
 };
-use leptos::task::{any_spawner, CustomExecutor};
 use parking_lot::Mutex;
 use std::{
     cell::RefCell,
@@ -40,6 +39,8 @@ use wasi::{
     clocks::monotonic_clock::{subscribe_duration, Duration},
     io::poll::{poll, Pollable},
 };
+
+use any_spawner::{CustomExecutor, PinnedFuture, PinnedLocalFuture};
 
 struct TableEntry(Pollable, Waker);
 
@@ -208,11 +209,11 @@ impl Executor {
 }
 
 impl CustomExecutor for Executor {
-    fn spawn(&self, fut: any_spawner::PinnedFuture<()>) {
+    fn spawn(&self, fut: PinnedFuture<()>) {
         self.0.spawner.spawn(fut).unwrap();
     }
 
-    fn spawn_local(&self, fut: any_spawner::PinnedLocalFuture<()>) {
+    fn spawn_local(&self, fut: PinnedLocalFuture<()>) {
         self.0.spawner.spawn_local(fut).unwrap();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! that you can leverage to use this crate.
 //!
 //! ```
-//! use leptos::task::Executor;
+//! use any_spawner::Executor;
 //! use leptos_wasi::prelude::WasiExecutor;
 //! use wasi::exports::http::incoming_handler::*;
 //!
@@ -50,6 +50,7 @@ pub mod prelude {
         executor::Executor as WasiExecutor, handler::Handler, response::Body,
         utils::redirect,
     };
+    pub use any_spawner::Executor;
     pub use http::StatusCode;
     pub use wasi::exports::wasi::http::incoming_handler::{
         IncomingRequest, ResponseOutparam,

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,11 @@ use futures::{Stream, StreamExt};
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use leptos_integration_utils::ExtendResponse;
 use parking_lot::RwLock;
+#[cfg(feature = "generic")]
 use server_fn::response::generic::Body as ServerFnBody;
+
+#[cfg(not(feature = "generic"))]
+use bytes::Bytes as ServerFnBody;
 use std::{pin::Pin, sync::Arc};
 use thiserror::Error;
 use wasi::http::types::{HeaderError, Headers};
@@ -55,12 +59,20 @@ pub enum Body {
     ),
 }
 
+#[cfg(feature = "generic")]
 impl From<ServerFnBody> for Body {
     fn from(value: ServerFnBody) -> Self {
         match value {
             ServerFnBody::Sync(data) => Self::Sync(data),
             ServerFnBody::Async(stream) => Self::Async(stream),
         }
+    }
+}
+
+#[cfg(not(feature = "generic"))]
+impl From<ServerFnBody> for Body {
+    fn from(value: ServerFnBody) -> Self {
+        Self::Sync(value)
     }
 }
 


### PR DESCRIPTION
## Update to server_fn 0.8.7 and leptos_integration_utils 0.8.5

### Tested with latest leptos 0.8.9


https://github.com/user-attachments/assets/3bc14817-29a0-400f-9aba-59fa35c5304b



### Changes Made:

**Migration to Updated Dependencies:**
- Updated codebase to be compatible with breaking changes in server_fn 0.8.7 and leptos_integration_utils 0.8.5

**Key Modifications:**

1. **ServerFn Trait Updates (`src/handler.rs`):**
   - Refactored `with_server_fn` method to handle new ServerFn trait structure
   - ServerFn no longer has `ServerRequest`/`ServerResponse` associated types
   - Updated to use `Protocol` associated type for method determination
   - `ServerFnTraitObj::new()` signature changed from 4 parameters to 1

2. **SSR Mode Handler Updates:**
   - Added third boolean parameter (`_islands_nav`) to all SSR mode closures (Async, InOrder, PartiallyBlocked/OutOfOrder)
   - Added 6th boolean parameter to `Response::from_app()` for out-of-order streaming support

3. **Middleware Updates:**
   - Modified `sfn.run()` to include error serialization function returning `Bytes`

4. **Import Updates (`src/lib.rs`):**
   - Migrated from `leptos::task::Executor` to `any_spawner::Executor`
   - Updated prelude exports to include the new Executor

5. **Documentation:**
   - Added comprehensive migration diagnostic comments documenting all API changes for future reference

### Impact:
- Ensures compatibility with latest versions of core dependencies
- Maintains existing functionality while adapting to new API requirements
- No breaking changes to the public API of leptos_wasi

This update is necessary to stay current with the evolving Leptos ecosystem and maintain compatibility with newer versions of dependencies.

