### PR TITLE
chore: upgrade dependencies to Leptos 0.8.19 & server_fn 0.8.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,16 @@ default = ["wasip2"]
 wasip2 = ["dep:wasi"]
 wasip3 = ["dep:wasip3"]
 islands-router = []
+
+[patch.crates-io]
+server_fn = { path = "../leptos_src/server_fn" }
+throw_error = { path = "../leptos_src/any_error" }
+leptos = { path = "../leptos_src/leptos" }
+leptos_dom = { path = "../leptos_src/leptos_dom" }
+leptos_meta = { path = "../leptos_src/meta" }
+leptos_router = { path = "../leptos_src/router" }
+tachys = { path = "../leptos_src/tachys" }
+hydration_context = { path = "../leptos_src/hydration_context" }
+leptos_integration_utils = { path = "../leptos_src/integrations/utils" }
+any_spawner = { path = "../leptos_src/any_spawner" }
+leptos_macro = { path = "../leptos_src/leptos_macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,15 @@ wasip3 = ["dep:wasip3"]
 islands-router = []
 
 [patch.crates-io]
-server_fn = { path = "../leptos_src/server_fn" }
-throw_error = { path = "../leptos_src/any_error" }
-leptos = { path = "../leptos_src/leptos" }
-leptos_dom = { path = "../leptos_src/leptos_dom" }
-leptos_meta = { path = "../leptos_src/meta" }
-leptos_router = { path = "../leptos_src/router" }
-tachys = { path = "../leptos_src/tachys" }
-hydration_context = { path = "../leptos_src/hydration_context" }
-leptos_integration_utils = { path = "../leptos_src/integrations/utils" }
-any_spawner = { path = "../leptos_src/any_spawner" }
-leptos_macro = { path = "../leptos_src/leptos_macro" }
+server_fn = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+throw_error = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_dom = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_meta = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_router = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+tachys = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+hydration_context = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_integration_utils = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+any_spawner = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_macro = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -64,15 +64,16 @@ bin-features = ["ssr"]
 bin-target-dir = "target/server"
 
 [patch.crates-io]
-server_fn = { path = "../../../leptos_src/server_fn" }
-throw_error = { path = "../../../leptos_src/any_error" }
-leptos = { path = "../../../leptos_src/leptos" }
-leptos_dom = { path = "../../../leptos_src/leptos_dom" }
-leptos_meta = { path = "../../../leptos_src/meta" }
-leptos_router = { path = "../../../leptos_src/router" }
-tachys = { path = "../../../leptos_src/tachys" }
-hydration_context = { path = "../../../leptos_src/hydration_context" }
-leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
-any_spawner = { path = "../../../leptos_src/any_spawner" }
-leptos_macro = { path = "../../../leptos_src/leptos_macro" }
+server_fn = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+throw_error = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_dom = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_meta = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_router = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+tachys = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+hydration_context = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_integration_utils = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+any_spawner = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_macro = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+
 

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -16,14 +16,14 @@ bytes = "1.7.2"
 console_error_panic_hook = "0.1"
 futures = "0.3.30"
 hydration_context = { version = "0.3.0" }
-leptos = { version = "0.8.9" }
-leptos_meta = { version = "0.8.5" }
-leptos_router = { version = "0.8.7" }
+leptos = { version = "0.8.19" }
+leptos_meta = { version = "0.8.6" }
+leptos_router = { version = "0.8.13" }
 leptos_wasi = { path = "../..", default-features = false, features = ["wasip3"], optional = true }
-server_fn = { version = "0.8.7", features = ["axum-no-default"] }
+server_fn = { version = "0.8.12", features = ["axum-no-default"] }
 spin-sdk = { version = "6.0.0", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "=0.2.103", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [features]
@@ -62,3 +62,17 @@ bin-profile-release = "wasm-release"
 bin-target-triple = "wasm32-wasip2"
 bin-features = ["ssr"]
 bin-target-dir = "target/server"
+
+[patch.crates-io]
+server_fn = { path = "../../../leptos_src/server_fn" }
+throw_error = { path = "../../../leptos_src/any_error" }
+leptos = { path = "../../../leptos_src/leptos" }
+leptos_dom = { path = "../../../leptos_src/leptos_dom" }
+leptos_meta = { path = "../../../leptos_src/meta" }
+leptos_router = { path = "../../../leptos_src/router" }
+tachys = { path = "../../../leptos_src/tachys" }
+hydration_context = { path = "../../../leptos_src/hydration_context" }
+leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
+any_spawner = { path = "../../../leptos_src/any_spawner" }
+leptos_macro = { path = "../../../leptos_src/leptos_macro" }
+

--- a/examples/spin-counter/Cargo.toml
+++ b/examples/spin-counter/Cargo.toml
@@ -46,15 +46,16 @@ lib-features = ["hydrate"]
 lib-default-features = false
 
 [patch.crates-io]
-server_fn = { path = "../../../leptos_src/server_fn" }
-throw_error = { path = "../../../leptos_src/any_error" }
-leptos = { path = "../../../leptos_src/leptos" }
-leptos_dom = { path = "../../../leptos_src/leptos_dom" }
-leptos_meta = { path = "../../../leptos_src/meta" }
-leptos_router = { path = "../../../leptos_src/router" }
-tachys = { path = "../../../leptos_src/tachys" }
-hydration_context = { path = "../../../leptos_src/hydration_context" }
-leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
-any_spawner = { path = "../../../leptos_src/any_spawner" }
-leptos_macro = { path = "../../../leptos_src/leptos_macro" }
+server_fn = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+throw_error = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_dom = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_meta = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_router = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+tachys = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+hydration_context = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_integration_utils = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+any_spawner = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_macro = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+
 

--- a/examples/spin-counter/Cargo.toml
+++ b/examples/spin-counter/Cargo.toml
@@ -11,14 +11,14 @@ crate-type = [ "cdylib" ]
 any_spawner = { version = "0.3.0", features = ["futures-executor"] }
 anyhow = "1"
 console_error_panic_hook = "0.1"
-leptos = { version = "0.8.9" }
-leptos_meta = { version = "0.8.5" }
-leptos_router = { version = "0.8.7" }
+leptos = { version = "0.8.19" }
+leptos_meta = { version = "0.8.6" }
+leptos_router = { version = "0.8.13" }
 leptos_wasi = { path = "../..", default-features = false, features = ["wasip3"], optional = true }
 spin-sdk = { version = "6.0.0", optional = true }
 wasi = { version = "0.14.7", optional = true }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
-wasm-bindgen = { version = "=0.2.103", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = ["Storage", "Window"], optional = true }
 
 [workspace]
@@ -44,3 +44,17 @@ bin-features = ["ssr"]
 bin-default-features = false
 lib-features = ["hydrate"]
 lib-default-features = false
+
+[patch.crates-io]
+server_fn = { path = "../../../leptos_src/server_fn" }
+throw_error = { path = "../../../leptos_src/any_error" }
+leptos = { path = "../../../leptos_src/leptos" }
+leptos_dom = { path = "../../../leptos_src/leptos_dom" }
+leptos_meta = { path = "../../../leptos_src/meta" }
+leptos_router = { path = "../../../leptos_src/router" }
+tachys = { path = "../../../leptos_src/tachys" }
+hydration_context = { path = "../../../leptos_src/hydration_context" }
+leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
+any_spawner = { path = "../../../leptos_src/any_spawner" }
+leptos_macro = { path = "../../../leptos_src/leptos_macro" }
+

--- a/tests/test-app/Cargo.lock
+++ b/tests/test-app/Cargo.lock
@@ -3,19 +3,8 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "any_spawner"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1384d3fe1eecb464229fcf6eebb72306591c56bf27b373561489458a7c73027d"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -250,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "const-str"
-version = "0.6.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451d0640545a0553814b4c646eb549343561618838e9b42495f466131fe3ad49"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
 
 [[package]]
 name = "const_format"
@@ -278,8 +267,6 @@ dependencies = [
 [[package]]
 name = "const_str_slice_concat"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67855af358fcb20fac58f9d714c94e2b228fe5694c1c9b4ead4a366343eda1b"
 
 [[package]]
 name = "convert_case"
@@ -334,20 +321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,8 +367,6 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "either_of"
 version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5060e0a4cbf26a87550792688ade88e6b8aec9208613631a7a363bda7bc2d4cd"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -623,12 +594,6 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -659,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -699,12 +664,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "hydration_context"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8714ae4adeaa846d838f380fbd72f049197de629948f91bf045329e0cf0a283"
 dependencies = [
  "futures",
  "js-sys",
- "once_cell",
  "or_poisoned",
  "pin-project-lite",
  "serde",
@@ -877,10 +839,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -908,16 +872,14 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leptos"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c98f6d751e524ff425ad9d63d53e120ed68311ffbc22bbd9c0b3c4005a421e"
+version = "0.8.19"
 dependencies = [
  "any_spawner",
  "base64",
  "cfg-if",
  "either_of",
  "futures",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hydration_context",
  "leptos_config",
  "leptos_dom",
@@ -940,8 +902,8 @@ dependencies = [
  "tachys",
  "thiserror 2.0.18",
  "throw_error",
- "typed-builder 0.22.0",
- "typed-builder-macro 0.22.0",
+ "typed-builder",
+ "typed-builder-macro",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm_split_helpers",
@@ -951,21 +913,16 @@ dependencies = [
 [[package]]
 name = "leptos_config"
 version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c06f751315bccc0d193fab302ac01d25bcfcd97474d4676440e7e3250dc3fc3"
 dependencies = [
  "config",
- "regex",
  "serde",
  "thiserror 2.0.18",
- "typed-builder 0.23.2",
+ "typed-builder",
 ]
 
 [[package]]
 name = "leptos_dom"
 version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35742e9ed8f8aaf9e549b454c68a7ac0992536e06856365639b111f72ab07884"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -979,8 +936,6 @@ dependencies = [
 [[package]]
 name = "leptos_hot_reload"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2a0f220c8a5ef3c51199dfb9cdd702bc0eb80d52fbe70c7890adfaaae8a4b1"
 dependencies = [
  "anyhow",
  "camino",
@@ -996,9 +951,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_integration_utils"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cccc9305df53757bae61bf15641bfa6a667b5f78456ace4879dfe0591ae0e8"
+version = "0.8.8"
 dependencies = [
  "futures",
  "hydration_context",
@@ -1012,8 +965,6 @@ dependencies = [
 [[package]]
 name = "leptos_macro"
 version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9360df573fb57582384a8b7640a3de94ce6501d49be3b69f637cf11a42da484b"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -1035,9 +986,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d489e38d3f541e9e43ecc2e3a815527840345a2afca629b3e23fcc1dd254578"
+version = "0.8.6"
 dependencies = [
  "futures",
  "indexmap",
@@ -1050,9 +999,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b824cae28db1551b71f8c2a45eab7bb98d61407f5adcc368cfe7b671e4a71d"
+version = "0.8.13"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -1076,8 +1023,6 @@ dependencies = [
 [[package]]
 name = "leptos_router_macro"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409c0bd99f986c3cfa1a4db2443c835bc602ded1a12784e22ecb28c3ed5a2ae2"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1087,9 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf1045af93050bf3388d1c138426393fc131f6d9e46a65519da884c033ed730"
+version = "0.8.7"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1231,14 +1174,10 @@ dependencies = [
 [[package]]
 name = "next_tuple"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
 name = "oco_ref"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0423ff9973dea4d6bd075934fdda86ebb8c05bdf9d6b0507067d4a1226371d"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1253,8 +1192,6 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "or_poisoned"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
 
 [[package]]
 name = "parking"
@@ -1487,8 +1424,6 @@ dependencies = [
 [[package]]
 name = "reactive_graph"
 version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c5a025366836190c7030e883cc2bcd9e384ff555336e3c7954741ca411b177"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -1511,8 +1446,6 @@ dependencies = [
 [[package]]
 name = "reactive_stores"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30fd35b7d299c591293bb69fed47a703eb2703b1cff0493e78b16ed007e5382"
 dependencies = [
  "guardian",
  "indexmap",
@@ -1528,8 +1461,6 @@ dependencies = [
 [[package]]
 name = "reactive_stores_macro"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d8e790a5ae5ddf9b7fa380c728375b06858e0cca7d063a73b3408320c523e1"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro-error2",
@@ -1546,35 +1477,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "routefinder"
@@ -1717,16 +1619,13 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc30228718f62d80a376964baf990edbcb5e97688fdc71183a8ef3d44cb6c89"
+version = "0.8.12"
 dependencies = [
  "axum",
  "base64",
  "bytes",
  "const-str",
  "const_format",
- "dashmap",
  "futures",
  "gloo-net",
  "http",
@@ -1734,6 +1633,7 @@ dependencies = [
  "hyper",
  "inventory",
  "js-sys",
+ "or_poisoned",
  "pin-project-lite",
  "rustc_version",
  "rustversion",
@@ -1757,8 +1657,6 @@ dependencies = [
 [[package]]
 name = "server_fn_macro"
 version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1295b54815397d30d986b63f93cfd515fa86d5e528e0bb589ce9d530502f9e0f"
 dependencies = [
  "const_format",
  "convert_case 0.11.0",
@@ -1772,8 +1670,6 @@ dependencies = [
 [[package]]
 name = "server_fn_macro_default"
 version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63eb08f80db903d3c42f64e60ebb3875e0305be502bdc064ec0a0eab42207f00"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1892,8 +1788,6 @@ dependencies = [
 [[package]]
 name = "tachys"
 version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2989c94c59db8497727875aa561d4d0daa3cc79b5774d5ced48263f7091beff1"
 dependencies = [
  "any_spawner",
  "async-trait",
@@ -1932,6 +1826,7 @@ dependencies = [
  "http",
  "hydration_context",
  "leptos",
+ "leptos_macro",
  "leptos_meta",
  "leptos_router",
  "leptos_wasi",
@@ -1984,8 +1879,6 @@ dependencies = [
 [[package]]
 name = "throw_error"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0ed6038fcbc0795aca7c92963ddda636573b956679204e044492d2b13c8f64"
 dependencies = [
  "pin-project-lite",
 ]
@@ -2068,31 +1961,11 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "typed-builder"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
-dependencies = [
- "typed-builder-macro 0.22.0",
-]
-
-[[package]]
-name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
 dependencies = [
- "typed-builder-macro 0.23.2",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48cea23f68d1f78eb7bc092881b6bb88d3d6b5b7e6234f6f9c911da1ffb221"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "typed-builder-macro",
 ]
 
 [[package]]
@@ -2229,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2241,37 +2114,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2279,22 +2135,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2323,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -2370,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/tests/test-app/Cargo.lock
+++ b/tests/test-app/Cargo.lock
@@ -5,6 +5,7 @@ version = 4
 [[package]]
 name = "any_spawner"
 version = "0.3.0"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -267,6 +268,7 @@ dependencies = [
 [[package]]
 name = "const_str_slice_concat"
 version = "0.1.0"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 
 [[package]]
 name = "convert_case"
@@ -367,6 +369,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 [[package]]
 name = "either_of"
 version = "0.1.9"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -664,6 +667,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "hydration_context"
 version = "0.3.0"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "futures",
  "js-sys",
@@ -872,6 +876,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "leptos"
 version = "0.8.19"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "any_spawner",
  "base64",
@@ -912,6 +917,7 @@ dependencies = [
 [[package]]
 name = "leptos_config"
 version = "0.8.10"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "config",
  "serde",
@@ -922,6 +928,7 @@ dependencies = [
 [[package]]
 name = "leptos_dom"
 version = "0.8.8"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -935,6 +942,7 @@ dependencies = [
 [[package]]
 name = "leptos_hot_reload"
 version = "0.8.6"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "anyhow",
  "camino",
@@ -951,6 +959,7 @@ dependencies = [
 [[package]]
 name = "leptos_integration_utils"
 version = "0.8.8"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "futures",
  "hydration_context",
@@ -964,6 +973,7 @@ dependencies = [
 [[package]]
 name = "leptos_macro"
 version = "0.8.16"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -986,6 +996,7 @@ dependencies = [
 [[package]]
 name = "leptos_meta"
 version = "0.8.6"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "futures",
  "indexmap",
@@ -999,6 +1010,7 @@ dependencies = [
 [[package]]
 name = "leptos_router"
 version = "0.8.13"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -1022,6 +1034,7 @@ dependencies = [
 [[package]]
 name = "leptos_router_macro"
 version = "0.8.6"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1032,6 +1045,7 @@ dependencies = [
 [[package]]
 name = "leptos_server"
 version = "0.8.7"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1173,10 +1187,12 @@ dependencies = [
 [[package]]
 name = "next_tuple"
 version = "0.1.0"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 
 [[package]]
 name = "oco_ref"
 version = "0.2.1"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1191,6 +1207,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "or_poisoned"
 version = "0.1.0"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 
 [[package]]
 name = "parking"
@@ -1423,6 +1440,7 @@ dependencies = [
 [[package]]
 name = "reactive_graph"
 version = "0.2.14"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -1445,6 +1463,7 @@ dependencies = [
 [[package]]
 name = "reactive_stores"
 version = "0.4.3"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "guardian",
  "indexmap",
@@ -1460,6 +1479,7 @@ dependencies = [
 [[package]]
 name = "reactive_stores_macro"
 version = "0.4.2"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro-error2",
@@ -1619,6 +1639,7 @@ dependencies = [
 [[package]]
 name = "server_fn"
 version = "0.8.12"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "axum",
  "base64",
@@ -1656,6 +1677,7 @@ dependencies = [
 [[package]]
 name = "server_fn_macro"
 version = "0.8.10"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "const_format",
  "convert_case 0.11.0",
@@ -1669,6 +1691,7 @@ dependencies = [
 [[package]]
 name = "server_fn_macro_default"
 version = "0.8.5"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "server_fn_macro",
  "syn",
@@ -1787,6 +1810,7 @@ dependencies = [
 [[package]]
 name = "tachys"
 version = "0.2.15"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "any_spawner",
  "async-trait",
@@ -1878,6 +1902,7 @@ dependencies = [
 [[package]]
 name = "throw_error"
 version = "0.3.1"
+source = "git+https://github.com/codeitlikemiley/leptos.git?rev=9b52b03d2b8a8016a264820f3035a3d61475a62f#9b52b03d2b8a8016a264820f3035a3d61475a62f"
 dependencies = [
  "pin-project-lite",
 ]

--- a/tests/test-app/Cargo.lock
+++ b/tests/test-app/Cargo.lock
@@ -668,7 +668,6 @@ dependencies = [
  "futures",
  "js-sys",
  "or_poisoned",
- "pin-project-lite",
  "serde",
  "throw_error",
  "wasm-bindgen",

--- a/tests/test-app/Cargo.toml
+++ b/tests/test-app/Cargo.toml
@@ -36,14 +36,15 @@ codegen-units = 1
 panic = "abort"
 
 [patch.crates-io]
-server_fn = { path = "../../../leptos_src/server_fn" }
-throw_error = { path = "../../../leptos_src/any_error" }
-leptos = { path = "../../../leptos_src/leptos" }
-leptos_dom = { path = "../../../leptos_src/leptos_dom" }
-leptos_meta = { path = "../../../leptos_src/meta" }
-leptos_router = { path = "../../../leptos_src/router" }
-tachys = { path = "../../../leptos_src/tachys" }
-hydration_context = { path = "../../../leptos_src/hydration_context" }
-leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
-any_spawner = { path = "../../../leptos_src/any_spawner" }
-leptos_macro = { path = "../../../leptos_src/leptos_macro" }
+server_fn = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+throw_error = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_dom = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_meta = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_router = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+tachys = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+hydration_context = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_integration_utils = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+any_spawner = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+leptos_macro = { git = "https://github.com/codeitlikemiley/leptos.git", rev = "9b52b03d2b8a8016a264820f3035a3d61475a62f" }
+

--- a/tests/test-app/Cargo.toml
+++ b/tests/test-app/Cargo.toml
@@ -12,14 +12,15 @@ any_spawner = { version = "0.3.0", features = ["futures-executor"] }
 bytes = "1.7.2"
 futures = "0.3.30"
 hydration_context = { version = "0.3.0" }
-leptos = { version = "0.8.9", default-features = false, features = ["ssr"] }
-leptos_meta = { version = "0.8.5", default-features = false, features = ["ssr"] }
-leptos_router = { version = "0.8.7", default-features = false, features = ["ssr"] }
+leptos = { version = "0.8.19", default-features = false, features = ["ssr"] }
+leptos_meta = { version = "0.8.6", default-features = false, features = ["ssr"] }
+leptos_router = { version = "0.8.13", default-features = false, features = ["ssr"] }
 leptos_wasi = { path = "../..", default-features = false }
-server_fn = { version = "0.8.7", default-features = false, features = ["axum-no-default"] }
+server_fn = { version = "0.8.12", default-features = false, features = ["axum-no-default"] }
 wasip3 = { version = "0.6.0", features = ["http-compat"], optional = true }
 wasi = { version = "0.14.7", optional = true }
-axum-core = "0.5.2"
+leptos_macro = { version = "0.8.16", default-features = false, features = ["generic"] }
+axum-core = "0.5.6"
 serde = { version = "1", features = ["derive"] }
 http = "1"
 
@@ -33,3 +34,16 @@ opt-level = 'z'
 lto = true
 codegen-units = 1
 panic = "abort"
+
+[patch.crates-io]
+server_fn = { path = "../../../leptos_src/server_fn" }
+throw_error = { path = "../../../leptos_src/any_error" }
+leptos = { path = "../../../leptos_src/leptos" }
+leptos_dom = { path = "../../../leptos_src/leptos_dom" }
+leptos_meta = { path = "../../../leptos_src/meta" }
+leptos_router = { path = "../../../leptos_src/router" }
+tachys = { path = "../../../leptos_src/tachys" }
+hydration_context = { path = "../../../leptos_src/hydration_context" }
+leptos_integration_utils = { path = "../../../leptos_src/integrations/utils" }
+any_spawner = { path = "../../../leptos_src/any_spawner" }
+leptos_macro = { path = "../../../leptos_src/leptos_macro" }


### PR DESCRIPTION
### Description
This PR upgrades the dependency version bounds in the `leptos_wasi` library, examples, and test application to use Leptos `0.8.19` and `server_fn` `0.8.12`.

To support compiling and running WASI targets with the new versions (resolving the unresolved `__wbindgen_placeholder__` linker issues reported in #21), this PR temporarily patches the crates to `codeitlikemiley/leptos` at commit `9b52b03d2b8a8016a264820f3035a3d61475a62f`, which contains the target-gating and internal mocks.

Once the corresponding upstream PR in `leptos-rs/leptos` (#4750) is merged and released, this patch block can be removed or pointed directly to the official crates.io release.
